### PR TITLE
Debug graphql execution error for model association changes

### DIFF
--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/bindingCommon.pure
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/bindingCommon.pure
@@ -67,7 +67,9 @@ function meta::external::query::graphQL::binding::customGraphQLScalarsToPrimitiv
     pair('StrictDate', 'String'),
     pair('DateTime', 'String'),
     pair('BigDecimal', 'Float'),
-    pair('Number', 'Float')
+    pair('Number', 'Float'),
+    // Treat Byte/Binary as base64-encoded string in input comparisons
+    pair('Byte', 'String')
   ])
 }
 

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/fromPure/introspection/fromPure_Introspection.pure
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/fromPure/introspection/fromPure_Introspection.pure
@@ -115,7 +115,9 @@ function <<access.private>> meta::external::query::graphQL::binding::fromPure::i
       pair('DateTime',^__Type(kind = __TypeKind.SCALAR,name = 'DateTime')),
       pair('Decimal',^__Type(kind = __TypeKind.SCALAR,name = 'BigDecimal')),
       pair('StrictDate',^__Type(kind = __TypeKind.SCALAR,name = 'StrictDate')),
-      pair('Number',^__Type(kind = __TypeKind.SCALAR,name = 'Number'))
+      pair('Number',^__Type(kind = __TypeKind.SCALAR,name = 'Number')),
+      // Map Pure Byte/Binary to GraphQL String for introspection output
+      pair('Byte',^__Type(kind = __TypeKind.SCALAR,name = 'String'))
     ]
   )->newMap();
 

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/fromPure/introspection/tests/byteReachabilityTest.pure
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/fromPure/introspection/tests/byteReachabilityTest.pure
@@ -1,0 +1,38 @@
+###Pure
+import meta::external::query::graphQL::metamodel::introspection::*;
+import meta::external::query::graphQL::transformation::introspection::*;
+import meta::external::query::graphQL::transformation::queryToPure::tests::*;
+
+// Minimal model to reproduce reachability of Byte-typed property via association
+Class meta::external::query::graphQL::binding::fromPure::introspection::tests::binary::DepositAccount
+{
+  currency: String[0..1];
+  virtualAccountIndicator: Byte[0..1];
+}
+
+Class meta::external::query::graphQL::binding::fromPure::introspection::tests::binary::Owner
+{
+}
+
+Association meta::external::query::graphQL::binding::fromPure::introspection::tests::binary::Owner_DepositAccount
+{
+  owner: meta::external::query::graphQL::binding::fromPure::introspection::tests::binary::Owner[1];
+  account: meta::external::query::graphQL::binding::fromPure::introspection::tests::binary::DepositAccount[*];
+}
+
+Class meta::external::query::graphQL::binding::fromPure::introspection::tests::binary::Query
+{
+  owners() {meta::external::query::graphQL::binding::fromPure::introspection::tests::binary::Owner.all()}: meta::external::query::graphQL::binding::fromPure::introspection::tests::binary::Owner[*];
+}
+
+// Pre-fix (without Byte scalar mapping), the call below would throw at fromPure_Introspection.pure line 278
+// due to missing map entry for 'Byte'. With the mapping present, it should succeed and include the field.
+function <<test.Test>> meta::external::query::graphQL::binding::fromPure::introspection::tests::testGraphQLIntrospection_BinaryFieldReachable(): Boolean[1]
+{
+  let doc = meta::external::query::graphQL::transformation::queryToPure::tests::buildIntrospectionQuery();
+  let result = meta::external::query::graphQL::transformation::introspection::graphQLIntrospectionQuery(meta::external::query::graphQL::binding::fromPure::introspection::tests::binary::Query, $doc);
+
+  // Sanity: ensure the reachable Byte-typed field is present in the introspection output
+  assert($result->contains('virtualAccountIndicator'), 'Expected virtualAccountIndicator in introspection result');
+}
+


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->
Bug Fix

#### What does this PR do / why is it needed ?

This PR fixes a "Cannot cast a collection of size 0 to multiplicity [1]" error encountered during GraphQL introspection. The error occurred because the `Byte` primitive type (which `Binary` properties map to) was missing from the GraphQL introspection scalar type map, causing the lookup to fail.

By adding `Byte` to map to `String` in both the introspection output and input scalar maps, `Binary` properties can now be correctly processed and exposed in GraphQL schemas.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:
The `Byte` primitive type is mapped to the GraphQL `String` scalar, which is a common representation for binary data (e.g., base64 encoded).

#### Does this PR introduce a user-facing change?
<!--
-->Yes

---
<a href="https://cursor.com/background-agent?bcId=bc-c35982a3-7d13-487a-bde5-bc218354a73b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c35982a3-7d13-487a-bde5-bc218354a73b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

